### PR TITLE
Threadsafe initialization of defaultTzDb

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup Nim environment
-      uses: jiro4989/setup-nim-action@v1.1.2
+      uses: jiro4989/setup-nim-action@v1
       with:
         nim-version: ${{ matrix.nim }}
 

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -129,3 +129,13 @@ when defined(posix):
         check zone1.countries == @["SE"]
         doAssertRaises(AssertionError):
             discard loadPosixTzInfo(zoneInfoPath / "Europe/Stockholm")
+
+test "Threading":
+    proc testThread() =
+        # check that the default databse is initialized thread-local
+        discard tz("America/New_York")
+
+    var thr: array[0..4, Thread[void]]
+    for i in 0..high(thr):
+        createThread(thr[i], testThread)
+    joinThreads(thr)

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -130,12 +130,13 @@ when defined(posix):
         doAssertRaises(AssertionError):
             discard loadPosixTzInfo(zoneInfoPath / "Europe/Stockholm")
 
-test "threading":
-    proc testThread() =
-        # check that the default database is initialized thread-local
-        discard tz("America/New_York")
+when not defined(js):
+    test "threading":
+        proc testThread() =
+            # check that the default database is initialized thread-local
+            discard tz("America/New_York")
 
-    var thr: array[0..4, Thread[void]]
-    for i in 0..high(thr):
-        createThread(thr[i], testThread)
-    joinThreads(thr)
+        var thr: array[0..4, Thread[void]]
+        for i in 0..high(thr):
+            createThread(thr[i], testThread)
+        joinThreads(thr)

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -130,9 +130,9 @@ when defined(posix):
         doAssertRaises(AssertionError):
             discard loadPosixTzInfo(zoneInfoPath / "Europe/Stockholm")
 
-test "Threading":
+test "threading":
     proc testThread() =
-        # check that the default databse is initialized thread-local
+        # check that the default database is initialized thread-local
         discard tz("America/New_York")
 
     var thr: array[0..4, Thread[void]]

--- a/timezones.nim
+++ b/timezones.nim
@@ -79,6 +79,41 @@ type
 
 var defaultTzDb {.threadvar.}: TimezoneDb
 
+when not defined(nimsuggest):
+    when not defined(timezonesPath):
+        from timezones / private / tzversion import TzDbVersion
+        const timezonesPath = "./" & TzDbVersion & ".json"
+    else:
+        const timezonesPath {.strdefine.} = ""
+        when not defined(js):
+            from os import isAbsolute
+            when not timezonesPath.isAbsolute:
+                {.error: "Path to custom tz data file must be absolute: '" &
+                    timezonesPath & "'".}
+        {.hint: "Embedding custom tz data file: " & timezonesPath.}
+
+when not defined(timezonesNoEmbeed) or defined(nimdoc):
+    const content = staticRead timezonesPath
+    defaultTzDb = parseTzData(content).TimezoneDb
+
+proc parseTzDb*(content: string): TimezoneDb =
+    ## Parse a timezone database from its JSON representation.
+    parseTzData(content).TimezoneDb
+
+when not defined(js):
+    proc parseTzDb*(s: Stream): TimezoneDb =
+        ## Parse a timezone database from its JSON representation.
+        parseTzData(s).TimezoneDb
+
+    proc loadTzDb*(path: string): TimezoneDb =
+        ## Load a timezone database from a JSON file.
+        let fs = openFileStream(path, fmRead)
+        defer: fs.close()
+        parseTzData(fs).TimezoneDb
+
+proc empty(db: TimezoneDb): bool {.inline.} =
+    len(timezonedbs.TimezoneDb(db).tzByName) == 0
+
 proc getTz(db: TimezoneDb, tzName: string): (bool, TimezoneInternal)
         {.inline, raises: [].} =
     let tz = timezonedbs.TimezoneDb(db).tzByName.getOrDefault(tzName)
@@ -158,6 +193,25 @@ proc tz*(db: TimezoneDb, tzName: string): Timezone {.raises: [ValueError].} =
                 "Timezone does not exist in database: " & tzName)
         result = newTimezone(tz)
 
+proc setDefaultTzDb*(db: TimezoneDb) =
+    ## Sets the timezone database that will be used for ``tz(tzName)`` and
+    ## ``tzInfo(tzName)``. The default timezone database is stored in a thread
+    ## local variable, so calling this only affects the calling thread!
+    defaultTzDb = db
+
+proc getDefaultTzDb*(): TimezoneDb =
+    ## Gets the timezone database that is used for ``tz(tzName)`` and
+    ## ``tzInfo(tzName)``. The default timezone database is stored in a thread
+    ## local varaible, so calling ``setDefaultTzDb`` only affects the calling
+    ## thread!
+    try:
+        if defaultTzDb.empty:
+            # thread-level initialization. static content is still used
+            setDefaultTzDb(parseTzDb(content))
+    except Exception:
+        raise newException(ValueError, "can not find local tz db")
+    defaultTzDb
+
 proc tz*(tzName: string): Timezone {.inline, raises: [ValueError].} =
     ## Convenience proc using the default timezone database.
     runnableExamples:
@@ -165,7 +219,7 @@ proc tz*(tzName: string): Timezone {.inline, raises: [ValueError].} =
         let stockholm = tz"Europe/Stockholm"
         let dt = initDateTime(1, mJan, 1850, 00, 00, 00, stockholm)
         doAssert $dt == "1850-01-01T00:00:00+01:12"
-    defaultTzDb.tz(tzName)
+    getDefaultTzDb().tz(tzName)
 
 proc tzInfo*(db: TimezoneDb, tzName: string): TimezoneInfo
              {.raises: [ValueError].}=
@@ -203,19 +257,6 @@ proc tzInfo*(tzName: string): TimezoneInfo {.inline, raises: [ValueError].} =
         doAssert $stockholmInfo.location == "Some(59° 20′ 0″ N 18° 3′ 0″ E)"
     defaultTzDb.tzInfo(tzName)
 
-proc setDefaultTzDb*(db: TimezoneDb) =
-    ## Sets the timezone database that will be used for ``tz(tzName)`` and
-    ## ``tzInfo(tzName)``. The default timezone database is stored in a thread
-    ## local variable, so calling this only affects the calling thread!
-    defaultTzDb = db
-
-proc getDefaultTzDb*(): TimezoneDb =
-    ## Gets the timezone database that is used for ``tz(tzName)`` and
-    ## ``tzInfo(tzName)``. The default timezone database is stored in a thread
-    ## local varaible, so calling ``setDefaultTzDb`` only affects the calling
-    ## thread!
-    defaultTzDb
-
 proc staticTz*(hours, minutes, seconds: int = 0): Timezone
                {.noSideEffect, raises: [].} =
     ## Create a timezone using a static offset from UTC.
@@ -247,38 +288,6 @@ proc staticTz*(hours, minutes, seconds: int = 0): Timezone
             "+" & offsetStr
 
     result = newTimezone(tzName, offset)
-
-proc parseTzDb*(content: string): TimezoneDb =
-    ## Parse a timezone database from its JSON representation.
-    parseTzData(content).TimezoneDb
-
-when not defined(js):
-    proc parseTzDb*(s: Stream): TimezoneDb =
-        ## Parse a timezone database from its JSON representation.
-        parseTzData(s).TimezoneDb
-
-    proc loadTzDb*(path: string): TimezoneDb =
-        ## Load a timezone database from a JSON file.
-        let fs = openFileStream(path, fmRead)
-        defer: fs.close()
-        parseTzData(fs).TimezoneDb
-
-when not defined(nimsuggest):
-    when not defined(timezonesPath):
-        from timezones / private / tzversion import TzDbVersion
-        const timezonesPath = "./" & TzDbVersion & ".json"
-    else:
-        const timezonesPath {.strdefine.} = ""
-        when not defined(js):
-            from os import isAbsolute
-            when not timezonesPath.isAbsolute:
-                {.error: "Path to custom tz data file must be absolute: '" &
-                    timezonesPath & "'".}
-        {.hint: "Embedding custom tz data file: " & timezonesPath.}
-
-when not defined(timezonesNoEmbeed) or defined(nimdoc):
-    const content = staticRead timezonesPath
-    defaultTzDb = parseTzData(content).TimezoneDb
 
 proc version*(db: TimezoneDb): string {.raises: [].} =
     ## The version of the IANA timezone database being represented by ``db``.

--- a/timezones.nim
+++ b/timezones.nim
@@ -255,7 +255,7 @@ proc tzInfo*(tzName: string): TimezoneInfo {.inline, raises: [ValueError].} =
         doAssert stockholmInfo.timezone == tz"Europe/Stockholm"
         doAssert stockholmInfo.countries == @["SE"]
         doAssert $stockholmInfo.location == "Some(59° 20′ 0″ N 18° 3′ 0″ E)"
-    defaultTzDb.tzInfo(tzName)
+    getdefaultTzDb().tzInfo(tzName)
 
 proc staticTz*(hours, minutes, seconds: int = 0): Timezone
                {.noSideEffect, raises: [].} =

--- a/timezones.nimble
+++ b/timezones.nimble
@@ -25,11 +25,11 @@ task test, "Run the tests":
 
     echo "\nRunning tests (C)"
     echo "==============="
-    exec "nim c --hints:off -r tests/tests.nim"
+    exec "nim c --hints:off --threads:on -r tests/tests.nim"
 
     echo "\nRunning tests (C in release mode)"
     echo "==============="
-    exec "nim c --hints:off -r -d:release tests/tests.nim"
+    exec "nim c --hints:off --threads:on -r -d:release tests/tests.nim"
 
     echo "\nRunning tests (JS)"
     echo "================"
@@ -37,7 +37,7 @@ task test, "Run the tests":
 
     echo "\nTesting -d:timezonesPath (C)"
     echo "================"
-    exec "nim c --hints:off -d:timezonesPath=\"" & tzdataPath &
+    exec "nim c --hints:off --threads:on -d:timezonesPath=\"" & tzdataPath &
         "\" -r tests/tests.nim"
 
     echo "\nTesting -d:timezonesPath (JS)"


### PR DESCRIPTION
At present, the top-level initialization of `defaultTzDb`:

```
when not defined(timezonesNoEmbeed) or defined(nimdoc):
    const content = staticRead timezonesPath
    defaultTzDb = parseTzData(content).TimezoneDb
```

will result in failing `tz(...)` calls in new threads as the initialization will not occur. To resolve this, this PR will initialize the `defaultTzDb` in `getDefaultTzDb` if it is not already initialized. Additionally, all usage of `defaultTzDb` is then done with `getDefaultTzDb`. This PR also adds a test using multiple threads. 
